### PR TITLE
Convenience printing to file

### DIFF
--- a/improvecentrality.py
+++ b/improvecentrality.py
@@ -473,6 +473,12 @@ def calculatecentralitydeltas(candidatekeys, graph, mynodekey):
     return centralitydeltas, myoldcentrality
 
 def printresults(centralitydeltas, mycurrentcentrality):
+    print('printing formatted pubkeys to use with BOS')
+    print('bos open $(cat centrality_pubkeys.txt)')
+    pubkeys = [f'{nkey} --amount=5000000' for nkey, _ in sorted(centralitydeltas.items(), key=lambda i:-i[1])]
+    with open("centrality_pubkeys.txt", "w") as file:
+        file.write('\n'.join(pubkeys))
+
     cols = 'Δcentr','MFscor','Avail','Relbty','Alias','Pubkey'
     print(*cols)
     exportdict = {k:[] for k in cols}


### PR DESCRIPTION
Lets the user easily run bos after running this script to batch open to the various centrality improving nodes.

Suggestions for further improvement
- allow user to put in an xpub or utxo and have this script a come up with a way to fully spend down the utxo amongst the various pub keys so that there is no change output (this can improve privacy and make node management more straightforward)